### PR TITLE
Added fix for window installation

### DIFF
--- a/windows/thermal_printer_plugin.cpp
+++ b/windows/thermal_printer_plugin.cpp
@@ -1,4 +1,4 @@
-#include "include/thermal_printer/thermal_printer.h"
+#include "include/thermal_printer/thermal_printer_plugin.h"
 
 // This must be included before many other Windows headers.
 #include <windows.h>


### PR DESCRIPTION
Due to typo, the plugin was giving this error when running on windows - 

```shell
windows\flutter\ephemeral\.plugin_symlinks\thermal_printer\windows\thermal_printer_plugin.cpp(1,10): error C1083: Cannot open include file: 'include/thermal_printer/thermal_printer.h': No such file or directory [build\windows\x64\plugins\thermal_printer\thermal_printer_plugin.vcxproj]
```